### PR TITLE
Crontab backup

### DIFF
--- a/telemetry/scripts/backup_crontabs
+++ b/telemetry/scripts/backup_crontabs
@@ -1,0 +1,20 @@
+#!/bin/bash
+# This script backs up all crontabs on a computer to a specified directory
+# Crontabs are read from /var/spool/cron/tabs/
+# Must be run as root user
+# Suggested usage: Run periodically on root user's crontab
+
+readonly BACKUP_DIR="/data/crontab_backup"
+
+date --utc
+
+# Make backup dir, root will be owner
+mkdir -p $BACKUP_DIR
+
+for user_crontab in /var/spool/cron/tabs/*; do
+    [[ -e $user_crontab ]] || echo "No crontabs found" && continue  # exit if no crontabs found
+    echo "Backing up crontab for $(basename)..."
+    cp --verbose $user_crontab "${BACKUP_DIR}/$(basename $user_crontab)-$(date --utc +"%Y%m%d")"
+done
+
+echo ""

--- a/telemetry/scripts/backup_crontabs
+++ b/telemetry/scripts/backup_crontabs
@@ -12,9 +12,11 @@ date --utc
 mkdir -p $BACKUP_DIR
 
 for user_crontab in /var/spool/cron/tabs/*; do
-    [[ -e $user_crontab ]] || echo "No crontabs found" && continue  # exit if no crontabs found
-    echo "Backing up crontab for $(basename)..."
-    cp --verbose $user_crontab "${BACKUP_DIR}/$(basename $user_crontab)-$(date --utc +"%Y%m%d")"
+    [[ -e $user_crontab ]] || continue  # exit if no crontabs found
+    echo "Backing up crontab for $(basename $user_crontab)..."
+    backup_file="${BACKUP_DIR}/$(basename $user_crontab)-$(date --utc +"%Y%m%d")"
+    cp --verbose $user_crontab $backup_file
+    chmod 664 $backup_file  # Give read permissions to all users  
 done
 
 echo ""

--- a/telemetry/scripts/backup_crontabs
+++ b/telemetry/scripts/backup_crontabs
@@ -16,7 +16,8 @@ for user_crontab in /var/spool/cron/tabs/*; do
     echo "Backing up crontab for $(basename $user_crontab)..."
     backup_file="${BACKUP_DIR}/$(basename $user_crontab)-$(date --utc +"%Y%m%d")"
     cp --verbose $user_crontab $backup_file
-    chmod 664 $backup_file  # Give read permissions to all users  
+    chmod 664 $backup_file          # Give read permissions to all users  
+    chown 1000:users $backup_file   # Make regular user owner and change group
 done
 
 echo ""


### PR DESCRIPTION
### Crontab backup
Created a script that copies all user's crontabs on a given computer to a specified directory. This script copies the crontabs found at `/var/spool/cron/tabs/`, and must be run as root user.

#### Testing
Ran the script as root user at `sasborealis` and successfully backed up the crontabs. To periodically back up the crontabs, I set up the following cronjob for the root user:

```crontab
0 0 * * MON /home/radar/edtk/telemetry/scripts/backup_crontabs >> /home/radar/logs/backup_crontabs.log 2>&1
```